### PR TITLE
Set floating pane to damaged to prevent swap layout

### DIFF
--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -2061,6 +2061,7 @@ impl Tab {
     ) -> Result<()> {
         let err_context = || format!("unable to resize float pane {pane_id:?} by given size");
 
+        self.swap_layouts.set_is_floating_damaged();
         self.floating_panes
             .resize_floating_pane(pane_id, &mut self.os_api, new_size)
             .with_context(err_context)?;


### PR DESCRIPTION
To fix issue 

1. Run zellij with compact mode
2. Run float plugin as float pane
3. Open a new float pane
4. resize the pane in # 3
5. exit plugin in # 2

Float pane will be reset to default size depends on `compact.swap.kdl`. 

By default - when zellij close a pane, it would check if tab should re-layout the pane by checking

```
            if self.auto_layout
                && !self.swap_layouts.is_floating_damaged()  -- This is the problem
                && self.floating_panes.visible_panes_count() > 0
```
